### PR TITLE
ENG-6032 publish broken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ trust-dns = ["reqwest/trust-dns"]
 test-registry = []
 
 [dependencies]
+base64 = "0.21"
 chrono = { version = "0.4.23", features = ["serde"] }
 futures = "0.3"
 futures-util = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -446,7 +446,7 @@ impl Client {
         }
 
         // Get the manifest and config from the from_ref
-        let (mut manifest, _, config_data) = from_client
+        let (manifest, _, config_data) = from_client
             .pull_manifest_and_config(from_ref, from_auth)
             .await?;
 
@@ -1079,7 +1079,7 @@ impl Client {
             .send()
             .await?
             .bytes_stream()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e));
+            .map_err(std::io::Error::other);
 
         Ok(FuturesAsyncReadCompatExt::compat(stream.into_async_read()))
     }
@@ -1204,7 +1204,7 @@ impl Client {
 
         let stream = ReaderStream::new(layer);
 
-        let res = RequestBuilderWrapper::from_client(&self, |client| client.put(&url))
+        let res = RequestBuilderWrapper::from_client(self, |client| client.put(&url))
             .apply_auth(image, RegistryOperation::Push)?
             .into_request_builder()
             .headers(headers)
@@ -1470,7 +1470,7 @@ impl<'a> RequestBuilderWrapper<'a> {
     fn from_client(
         client: &'a Client,
         f: impl Fn(&reqwest::Client) -> RequestBuilder,
-    ) -> RequestBuilderWrapper {
+    ) -> RequestBuilderWrapper<'a> {
         let request_builder = f(&client.client);
         RequestBuilderWrapper {
             client,
@@ -1486,7 +1486,7 @@ impl<'a> RequestBuilderWrapper<'a> {
 
 // Composable functions applicable to a `RequestBuilderWrapper`
 impl<'a> RequestBuilderWrapper<'a> {
-    fn apply_accept(&self, accept: &[&str]) -> Result<RequestBuilderWrapper> {
+    fn apply_accept(&self, accept: &[&str]) -> Result<RequestBuilderWrapper<'_>> {
         let request_builder = self
             .request_builder
             .try_clone()
@@ -1513,7 +1513,7 @@ impl<'a> RequestBuilderWrapper<'a> {
         &self,
         image: &Reference,
         op: RegistryOperation,
-    ) -> Result<RequestBuilderWrapper> {
+    ) -> Result<RequestBuilderWrapper<'_>> {
         let mut headers = HeaderMap::new();
 
         if let Some(token) = self.client.tokens.get(image, op) {
@@ -1637,7 +1637,7 @@ pub fn linux_amd64_resolver(manifests: &[ImageIndexEntry]) -> Option<String> {
     manifests
         .iter()
         .find(|entry| {
-            entry.platform.as_ref().map_or(false, |platform| {
+            entry.platform.as_ref().is_some_and(|platform| {
                 platform.os == "linux" && platform.architecture == "amd64"
             })
         })
@@ -1682,7 +1682,7 @@ pub fn current_platform_resolver(manifests: &[ImageIndexEntry]) -> Option<String
     manifests
         .iter()
         .find(|entry| {
-            entry.platform.as_ref().map_or(false, |platform| {
+            entry.platform.as_ref().is_some_and(|platform| {
                 platform.os == go_os() && platform.architecture == go_arch()
             })
         })
@@ -1700,6 +1700,7 @@ pub enum ClientProtocol {
     HttpsExcept(Vec<String>),
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for ClientProtocol {
     fn default() -> Self {
         ClientProtocol::Https
@@ -1746,7 +1747,6 @@ impl TryFrom<&HeaderValue> for BearerChallenge {
                     None
                 }
             })
-            .into_iter()
             .next()
             .ok_or_else(|| "Cannot find Bearer challenge".to_string())
     }
@@ -2076,7 +2076,7 @@ mod test {
     #[test]
     fn can_generate_valid_digest() {
         let bytes = b"hellobytes";
-        let hash = sha256_digest(&bytes.to_vec());
+        let hash = sha256_digest(bytes.as_ref());
 
         let combination = vec![b"hello".to_vec(), b"bytes".to_vec()];
         let combination_hash =
@@ -2786,7 +2786,7 @@ mod test {
 
         c.push_stream(
             &dest_image,
-            pushed_layers,
+            stream::iter(pushed_layers.into_iter().map(Ok)),
             config,
             &RegistryAuth::Anonymous,
             manifest,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1637,9 +1637,10 @@ pub fn linux_amd64_resolver(manifests: &[ImageIndexEntry]) -> Option<String> {
     manifests
         .iter()
         .find(|entry| {
-            entry.platform.as_ref().is_some_and(|platform| {
-                platform.os == "linux" && platform.architecture == "amd64"
-            })
+            entry
+                .platform
+                .as_ref()
+                .is_some_and(|platform| platform.os == "linux" && platform.architecture == "amd64")
         })
         .map(|entry| entry.digest.clone())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,8 +133,7 @@ struct Empty {}
 /// Helper to deserialize a `map[string]struct{}` of golang
 fn hashset_from_str<'de, D: Deserializer<'de>>(d: D) -> Result<HashSet<String>, D::Error> {
     let res = <HashMap<String, Empty>>::deserialize(d)?
-        .into_iter()
-        .map(|(k, _)| k)
+        .into_keys()
         .collect();
     Ok(res)
 }
@@ -275,7 +274,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use assert_json_diff::assert_json_eq;
-    use chrono::{TimeZone, Utc};
+    use chrono::{DateTime, Utc};
     use serde_json::Value;
 
     use super::{Architecture, Config, ConfigFile, History, Os, Rootfs};
@@ -375,14 +374,14 @@ mod tests {
         };
 
         let history = vec![History {
-            created: Some(Utc.datetime_from_str("2015-10-31T22:22:54.690851953Z", "%+").expect("parse time failed")),
+            created: Some(DateTime::parse_from_str("2015-10-31T22:22:54.690851953Z", "%+").expect("parse time failed").with_timezone(&Utc)),
             author: None,
             created_by: Some("/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /".into()),
             comment: None,
             empty_layer: None,
         },
         History {
-            created: Some(Utc.datetime_from_str("2015-10-31T22:22:55.613815829Z", "%+").expect("parse time failed")),
+            created: Some(DateTime::parse_from_str("2015-10-31T22:22:55.613815829Z", "%+").expect("parse time failed").with_timezone(&Utc)),
             author: None,
             created_by: Some("/bin/sh -c #(nop) CMD [\"sh\"]".into()),
             comment: None,
@@ -390,8 +389,9 @@ mod tests {
         }];
         ConfigFile {
             created: Some(
-                Utc.datetime_from_str("2015-10-31T22:22:56.015925234Z", "%+")
-                    .expect("parse time failed"),
+                DateTime::parse_from_str("2015-10-31T22:22:56.015925234Z", "%+")
+                    .expect("parse time failed")
+                    .with_timezone(&Utc),
             ),
             author: Some("Alyssa P. Hacker <alyspdev@example.com>".into()),
             architecture: Architecture::Amd64,
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn serialize() {
-        let serialized = serde_json::to_value(&example_config()).expect("serialize failed");
+        let serialized = serde_json::to_value(example_config()).expect("serialize failed");
         let parsed: Value = serde_json::from_str(EXAMPLE_CONFIG).expect("parsed failed");
         assert_json_eq!(serialized, parsed);
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -402,7 +402,7 @@ pub struct Platform {
     /// This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature.
     /// When `os` is `windows`, image indexes SHOULD use, and implementations SHOULD understand the following values:
     /// - `win32k`: image requires `win32k.sys` on the host (Note: `win32k.sys` is missing on Nano Server)
-    /// When `os` is not `windows`, values are implementation-defined and SHOULD be submitted to this specification for standardization.
+    ///   When `os` is not `windows`, values are implementation-defined and SHOULD be submitted to this specification for standardization.
     #[serde(rename = "os.features")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_features: Option<Vec<String>>,

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -1,9 +1,68 @@
 use crate::reference::Reference;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, warn};
+
+/// Flexible access field that can be either a string or an array
+/// to handle both old and new JWT token formats from registry providers
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // Fields are part of JWT API structure, may be used for future features
+pub enum AccessField {
+    String(String),
+    Array(Vec<AccessEntry>),
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)] // Fields are part of JWT access structure, may be used for future features
+pub struct AccessEntry {
+    #[serde(rename = "type")]
+    pub access_type: String,
+    pub name: String,
+    pub actions: Vec<String>,
+}
+
+impl<'de> Deserialize<'de> for AccessField {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // First try to deserialize as a string
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum AccessFieldHelper {
+            String(String),
+            Array(Vec<AccessEntry>),
+        }
+
+        match AccessFieldHelper::deserialize(deserializer)? {
+            AccessFieldHelper::String(s) => Ok(AccessField::String(s)),
+            AccessFieldHelper::Array(a) => Ok(AccessField::Array(a)),
+        }
+    }
+}
+
+/// Custom JWT claims structure that handles flexible access field
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)] // Fields are part of JWT claims structure, may be used for future features
+pub struct FlexibleJwtClaims {
+    #[serde(rename = "exp")]
+    pub expiration: Option<u64>,
+    #[serde(rename = "iat")]
+    pub issued_at: Option<u64>,
+    #[serde(rename = "sub")]
+    pub subject: Option<String>,
+    #[serde(rename = "aud")]
+    pub audience: Option<Vec<String>>,
+    #[serde(rename = "iss")]
+    pub issuer: Option<String>,
+    #[serde(rename = "jti")]
+    pub jti: Option<String>,
+    #[serde(rename = "nbf")]
+    pub not_before: Option<u64>,
+    pub access: Option<AccessField>,
+}
 
 /// A token granted during the OAuth2-like workflow for OCI registries.
 #[derive(Deserialize, Clone)]
@@ -82,18 +141,31 @@ impl TokenCache {
                 let token_str = t.token();
                 match jwt::Token::<
                         jwt::header::Header,
-                        jwt::claims::Claims,
+                        FlexibleJwtClaims,
                         jwt::token::Unverified,
                     >::parse_unverified(token_str)
                     {
-                        Ok(token) => token.claims().registered.expiration.unwrap_or(u64::MAX),
+                        Ok(token) => {
+                            debug!("Successfully parsed JWT token with flexible claims");
+                            token.claims().expiration.unwrap_or(u64::MAX)
+                        },
                         Err(jwt::Error::NoClaimsComponent) => {
                             debug!(?token, "Cannot extract expiration from token's claims, assuming forever");
                             u64::MAX
                         },
                         Err(error) => {
-                            warn!(?error, "Invalid bearer token");
-                            return;
+                            // If flexible parsing fails, try to extract expiration manually
+                            warn!(?error, "Failed to parse JWT with flexible claims, trying manual extraction");
+                            match extract_expiration_manually(token_str) {
+                                Some(exp) => {
+                                    debug!("Successfully extracted expiration manually: {}", exp);
+                                    exp
+                                },
+                                None => {
+                                    warn!("Failed to extract expiration manually, assuming forever");
+                                    u64::MAX
+                                }
+                            }
                         }
                     }
             }
@@ -136,5 +208,128 @@ impl TokenCache {
 
     pub(crate) fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
         self.get(reference, op).is_some()
+    }
+}
+
+/// Manual JWT expiration extraction as fallback when structured parsing fails
+fn extract_expiration_manually(token: &str) -> Option<u64> {
+    // JWT format: header.payload.signature
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        warn!("Invalid JWT format: expected 3 parts, got {}", parts.len());
+        return None;
+    }
+
+    // Decode the payload (base64url)
+    let payload = parts[1];
+    match base64_url_decode(payload) {
+        Ok(decoded) => match serde_json::from_slice::<serde_json::Value>(&decoded) {
+            Ok(claims) => {
+                if let Some(exp) = claims.get("exp") {
+                    if let Some(exp_num) = exp.as_u64() {
+                        debug!("Extracted expiration from JWT payload: {}", exp_num);
+                        return Some(exp_num);
+                    } else if let Some(exp_f64) = exp.as_f64() {
+                        let exp_u64 = exp_f64 as u64;
+                        debug!(
+                            "Extracted expiration from JWT payload (converted from f64): {}",
+                            exp_u64
+                        );
+                        return Some(exp_u64);
+                    }
+                }
+                debug!("No 'exp' field found in JWT claims");
+                None
+            }
+            Err(e) => {
+                warn!("Failed to parse JWT payload as JSON: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            warn!("Failed to decode JWT payload: {}", e);
+            None
+        }
+    }
+}
+
+/// Base64 URL decode (without padding)
+fn base64_url_decode(input: &str) -> Result<Vec<u8>, String> {
+    use base64::{engine::general_purpose, Engine as _};
+
+    // Add padding if needed
+    let mut padded = input.to_string();
+    while !padded.len().is_multiple_of(4) {
+        padded.push('=');
+    }
+
+    // Replace URL-safe characters
+    let standard = padded
+        .chars()
+        .map(|c| match c {
+            '-' => '+',
+            '_' => '/',
+            c => c,
+        })
+        .collect::<String>();
+
+    general_purpose::STANDARD
+        .decode(&standard)
+        .map_err(|e| format!("Base64 decode error: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flexible_jwt_claims_array_format() {
+        // Test Replicated's actual JWT format
+        let replicated_jwt_payload = r#"{
+            "access": [{"type":"repository","name":"proxy/wallaroo/ghcr.io/wallaroolabs/fitzroy-mini","actions":["pull"]}],
+            "exp": 1774988620
+        }"#;
+
+        let claims: FlexibleJwtClaims = serde_json::from_str(replicated_jwt_payload).unwrap();
+        assert_eq!(claims.expiration, Some(1774988620));
+
+        if let Some(AccessField::Array(entries)) = claims.access {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].access_type, "repository");
+            assert_eq!(
+                entries[0].name,
+                "proxy/wallaroo/ghcr.io/wallaroolabs/fitzroy-mini"
+            );
+            assert_eq!(entries[0].actions, vec!["pull"]);
+        } else {
+            panic!("Expected AccessField::Array");
+        }
+    }
+
+    #[test]
+    fn test_flexible_jwt_claims_string_format() {
+        // Test legacy string format
+        let legacy_jwt_payload = r#"{
+            "access": "some-string-format",
+            "exp": 1774988620
+        }"#;
+
+        let claims: FlexibleJwtClaims = serde_json::from_str(legacy_jwt_payload).unwrap();
+        assert_eq!(claims.expiration, Some(1774988620));
+
+        if let Some(AccessField::String(access_str)) = claims.access {
+            assert_eq!(access_str, "some-string-format");
+        } else {
+            panic!("Expected AccessField::String");
+        }
+    }
+
+    #[test]
+    fn test_manual_jwt_extraction() {
+        // Real JWT token with array access field
+        let test_jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3MiOlt7InR5cGUiOiJyZXBvc2l0b3J5IiwibmFtZSI6InByb3h5L3dhbGxhcm9vL2doci5pby93YWxsYXJvb2xhYnMvZml0enJveS1taW5pIiwiYWN0aW9ucyI6WyJwdWxsIl19XSwiZXhwIjoxNzc0OTg4NjIwfQ.signature";
+
+        let exp = extract_expiration_manually(test_jwt).unwrap();
+        assert_eq!(exp, 1774988620);
     }
 }


### PR DESCRIPTION
Bug repro is very simply to try "pipeline.publish()" and we fail.  Build tested on Staging where it now publishes.

Bot said:

Root Cause: jsonwebtoken v9.0.0 Breaking Change
The Breaking Change
The critical change was introduced in jsonwebtoken version 9.0.0 (released October 16, 2023):
> "Rejects JWTs containing audiences when the Validation doesn't contain any"
What Changed
1. Stricter Audience Validation: The crate became much more strict about validating JWT claims structure
2. Type Enforcement: Started rejecting tokens where field types don't match expectations
3. Array vs String Handling: The crate expects specific data types and rejects mismatched formats
 
Your Platform's Timeline
Looking at your Wallaroo platform:
- Previous: Used jsonwebtoken 9.3.1 
- Current: Updated to jsonwebtoken 10.3.0 (includes all v9.0.0+ breaking changes)
- Update Date: March 25, 2026 (commit 7c5d196ac)
 
The Specific Problem
Replicated's JWT tokens contain:
{
  "access": [{"type":"repository","name":"proxy/wallaroo/...","actions":["pull"]}]
}
But the JWT crate after v9.0.0 expects:
{
  "access": "string_value"
}

Why This Wasn't Caught Earlier
The issue likely manifested recently because:
1. Version Jump: Your platform jumped from 9.3.1 to 10.3.0, skipping the breaking v9.0.0 change
2. Code Path: The stricter validation may only trigger in certain code paths (like token caching)
3. Timing: Different operations might use different JWT parsing logic
